### PR TITLE
removed override from createJSModules

### DIFF
--- a/android/src/main/java/com/microsoft/aad/adal/rn/RNAdalPackage.java
+++ b/android/src/main/java/com/microsoft/aad/adal/rn/RNAdalPackage.java
@@ -29,7 +29,7 @@ public class RNAdalPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // deprecated
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
 it is removed from react-native 0.47.0 and is no longer overridable

[Remove unused createJSModules](https://github.com/facebook/react-native/releases/tag/v0.47.0)